### PR TITLE
Switch to compliant base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/python:latest
+FROM registry.opensource.zalan.do/library/python-3.8-slim:latest
 
 COPY requirements.txt /
 RUN pip3 install -r /requirements.txt


### PR DESCRIPTION
Switching to registry.opensource.zalan.do/library/python-3.8-slim from the official library 