### PR TITLE
Update compliant image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/python-3.9-slim:latest
+FROM container-registry.zalando.net/library/python-3.9-slim:latest
 
 COPY requirements.txt /
 RUN pip3 install -r /requirements.txt


### PR DESCRIPTION
Deploy pipeline fails because image is not compliant.